### PR TITLE
Build Fixes, CI Improvements, and Windows 7 fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Install MinGW toolchain
       run: |
-        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-13.2-binutils-2.41-mingw-v11.0.1-i686.tar.xz -o /tmp/mingw.tar.xz
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-13.2-binutils-2.41-mingw-v11.0.1-i686-v2.tar.xz -o /tmp/mingw.tar.xz
         sudo tar -xf /tmp/mingw.tar.xz -C /opt
 
     - name: Extract updroots.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,12 @@ jobs:
         sudo apt-get update -q
         sudo apt-get install -qy make nsis nsis-pluginapi mingw-w64-i686-dev cabextract
 
+    - name: Install MinGW toolchain
+      run: |
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-13.2-binutils-2.41-mingw-v11.0.1-i686.tar.xz -o /tmp/mingw.tar.xz
+        sudo tar -xf /tmp/mingw.tar.xz -C /opt
+        export PATH=/opt/gcc-13.2-binutils-2.41-mingw-v11.0.1-i686/bin:$PATH
+
     - name: Extract updroots.exe
       run: |
         curl -fsSL http://download.windowsupdate.com/d/msdownload/update/software/secu/2015/03/rvkroots_3f2ce4676450c06f109b5b4e68bec252873ccc21.exe -o /tmp/rvkroots.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,6 @@ jobs:
       run: |
         curl -fsSL https://linuxfromscratch.org/~renodr/gcc-13.2-binutils-2.41-mingw-v11.0.1-i686.tar.xz -o /tmp/mingw.tar.xz
         sudo tar -xf /tmp/mingw.tar.xz -C /opt
-        export PATH=/opt/gcc-13.2-binutils-2.41-mingw-v11.0.1-i686/bin:$PATH
 
     - name: Extract updroots.exe
       run: |
@@ -54,6 +53,7 @@ jobs:
     - name: Build
       id: build
       run: |
+        export PATH=/opt/gcc-13.2-binutils-2.41-mingw-v11.0.1-i686/bin:$PATH
         make CI=1 SIGN=0
         echo "out=$(echo setup/LegacyUpdate-*.exe)" >> "$(wslpath -u "$GITHUB_OUTPUT")"
 

--- a/setup/DownloadVista7.nsh
+++ b/setup/DownloadVista7.nsh
@@ -96,7 +96,7 @@ FunctionEnd
 ; Windows 7 Servicing Stack Update
 !insertmacro MSUHandler "KB3138612" "2016-03 Servicing Stack Update for Windows 7"           "Package_for_KB3138612"
 !insertmacro MSUHandler "KB4474419" "SHA-2 Code Signing Support Update for Windows 7"        "Package_for_KB4474419"
-!insertmacro MSUHandler "KB4490628" "2019-03 Servicing Stack Update for Windows 7"           "Package_for_KB3138612"
+!insertmacro MSUHandler "KB4490628" "2019-03 Servicing Stack Update for Windows 7"           "Package_for_KB4490628"
 
 ; Windows Home Server 2011 Update Rollup 4
 !insertmacro MSUHandler "KB2757011" "Windows Home Server 2011 Update Rollup 4"               "Package_for_KB2757011"

--- a/setup/Makefile
+++ b/setup/Makefile
@@ -6,7 +6,7 @@ setup:
 	makensis -DSIGN=$(SIGN) setup.nsi
 
 activex:
-	cp $(wildcard LegacyUpdate-*.exe) codebase/setup.exe
+	cp LegacyUpdate-*.exe codebase/setup.exe
 	cd codebase && makecab.exe /f lucontrl.ddf
 ifeq ($(SIGN),1)
 	../build/sign.sh codebase/lucontrl.cab

--- a/setup/setup.nsi
+++ b/setup/setup.nsi
@@ -520,9 +520,6 @@ FunctionEnd
 	!insertmacro EnsureAdminRights
 	SetDetailsPrint listonly
 
-!if ${SIGN} != 1
-	Debug::Watcher
-!endif
 !macroend
 
 Function .onInit


### PR DESCRIPTION
This pull request fixes several problems in the build system, fixes the CI, and fixes #205 (KB4490628 does not install)

In the case of the build system fixes, I've removed an old debugging statement that causes NSIS to fail when not signing, and I've also fixed a wildcard-related problem. 😃 

For the CI fix, after talking with Kirb, I've rolled my own MinGW toolchain for use with the CI system (and other systems that use Ubuntu 22.04). This is based on a much newer version than what Ubuntu provides and fixes the Segmentation Fault that occurs when building the NSIS plugin with the CI system.

For the Windows 7 fix, I've updated KB4490628 to say "Package_for_KB4490628" instead of "Package_for_KB3138612"