### PR TITLE
Update the CI to the new toolchain update for October 2024

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,17 +39,17 @@ jobs:
           --quiet --norestart --noUpdateInstaller \
           --installPath "$vs" \
           --config .vsconfig
-        if [ $? != 0 ]; then
-          cd /tmp
-          curl -fsSL https://aka.ms/vscollect.exe -o vscollect.exe
-          chmod +x vscollect.exe
-          ./vscollect.exe
-          unzip vscollect.zip
-          cat *.log
-          exit 1
-        else
-          echo "Installation of Visual Studio was successful."
-        fi
+        #if [ $? != 0 ]; then
+        #  cd /tmp
+        #  curl -fsSL https://aka.ms/vscollect.exe -o vscollect.exe
+        #  chmod +x vscollect.exe
+        #  ./vscollect.exe
+        #  unzip vscollect.zip
+        #  cat *.log
+        #  exit 1
+        #else
+        #  echo "Installation of Visual Studio was successful."
+        #fi
 
 
     - name: Install MinGW toolchain

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up WSL
       run: |
         sudo apt-get update -q
-        sudo apt-get install -qy cabextract curl make mingw-w64-x86-64-dev nsis nsis-pluginapi p7zip-full upx-ucl
+        sudo apt-get install -qy cabextract curl make mingw-w64-x86-64-dev nsis nsis-pluginapi p7zip-full upx-ucl unzip
         ./build/fix-nsis.sh
 
     - name: Set up Visual Studio

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,13 @@ jobs:
       run: |
         PATH='/mnt/c/Program Files (x86)/Microsoft Visual Studio/Installer':$PATH
         vs="$(vswhere.exe -latest -property installationPath | tr -d '\r')"
-        if ! vs_installer.exe modify \
+        vs_installer.exe modify \
           --quiet --norestart --noUpdateInstaller \
           --installPath "$vs" \
-          --config .vsconfig; then
-          echo "vs_installer.exe exit code: $?"
+          --config .vsconfig
+        RESULT=$?
+        echo "vs_installer.exe exit code: $RESULT"
+        if [ $RESULT != 0]; then
           cd /tmp
           curl -fsSL https://aka.ms/vscollect.exe -o vscollect.exe
           chmod +x vscollect.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,7 @@ jobs:
           --quiet --norestart --noUpdateInstaller \
           --installPath "$vs" \
           --config .vsconfig
-        RESULT=$?
-        echo "vs_installer.exe exit code: $RESULT"
-        if [ $RESULT != 0]; then
+        if [ $? == 0 ]; then
           cd /tmp
           curl -fsSL https://aka.ms/vscollect.exe -o vscollect.exe
           chmod +x vscollect.exe
@@ -49,6 +47,8 @@ jobs:
           unzip vscollect.zip
           cat *.log
           exit 1
+        else
+          echo "Installation of Visual Studio was successful."
         fi
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,18 +39,12 @@ jobs:
           --quiet --norestart --noUpdateInstaller \
           --installPath "$vs" \
           --config .vsconfig
-        #if [ $? != 0 ]; then
-        #  cd /tmp
-        #  curl -fsSL https://aka.ms/vscollect.exe -o vscollect.exe
-        #  chmod +x vscollect.exe
-        #  ./vscollect.exe
-        #  unzip vscollect.zip
-        #  cat *.log
-        #  exit 1
-        #else
-        #  echo "Installation of Visual Studio was successful."
-        #fi
-
+        cd /tmp
+        curl -fsSL https://aka.ms/vscollect.exe -o vscollect.exe
+        chmod +x vscollect.exe
+        ./vscollect.exe
+        unzip vscollect.zip || true
+        cat *.log || true
 
     - name: Install MinGW toolchain
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           --quiet --norestart --noUpdateInstaller \
           --installPath "$vs" \
           --config .vsconfig
-        if [ $? == 0 ]; then
+        if [ $? != 0 ]; then
           cd /tmp
           curl -fsSL https://aka.ms/vscollect.exe -o vscollect.exe
           chmod +x vscollect.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,11 @@ jobs:
 
     - name: Install MinGW toolchain
       run: |
-        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-13.2-binutils-2.41-mingw-v11.0.1-i686-v2.tar.xz -o /tmp/mingw.tar.xz
-        sudo tar -xf /tmp/mingw.tar.xz -C /opt
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686.tar.xz -o /tmp/mingw32.tar.xz
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64.tar.xz -o /tmp/mingw64.tar.xz
+        sudo tar -xf /tmp/mingw32.tar.xz -C /opt
+        sudo tar -xf /tmp/mingw64.tar.xz -C /opt
+        rm /tmp/mingw{32,64}.tar.xz
 
     - name: Extract updroots.exe
       run: |
@@ -64,7 +67,8 @@ jobs:
     - name: Build
       id: build
       run: |
-        export PATH=/opt/gcc-13.2-binutils-2.41-mingw-v11.0.1-i686/bin:$PATH
+        export PATH=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686/bin:$PATH
+        export PATH=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64/bin:$PATH
         make CI=1 DEBUG=0
         echo "out=$(echo setup/LegacyUpdate-*.exe)" >> "$(wslpath -u "$GITHUB_OUTPUT")"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,8 @@ jobs:
 
     - name: Install MinGW toolchain
       run: |
-        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686.tar.xz -o /tmp/mingw32.tar.xz
-        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64.tar.xz -o /tmp/mingw64.tar.xz
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686-v2.tar.xz -o /tmp/mingw32.tar.xz
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64-v2.tar.xz -o /tmp/mingw64.tar.xz
         sudo tar -xf /tmp/mingw32.tar.xz -C /opt
         sudo tar -xf /tmp/mingw64.tar.xz -C /opt
         rm /tmp/mingw{32,64}.tar.xz

--- a/.vsconfig
+++ b/.vsconfig
@@ -19,5 +19,4 @@
     "Microsoft.VisualStudio.Component.WinXP",
     "Microsoft.VisualStudio.Component.VC.v141.ATL"
   ],
-  "extensions": []
 }

--- a/.vsconfig
+++ b/.vsconfig
@@ -1,22 +1,8 @@
 {
   "version": "1.0",
   "components": [
-    "Microsoft.VisualStudio.Component.CoreEditor",
-    "Microsoft.VisualStudio.Workload.CoreEditor",
-    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
-    "Microsoft.Component.MSBuild",
-    "Microsoft.VisualStudio.Component.TextTemplating",
-    "Microsoft.VisualStudio.Component.VC.CoreIde",
-    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-    "Microsoft.VisualStudio.Component.Windows11SDK.22621",
-    "Microsoft.VisualStudio.Component.VC.ATL",
-    "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
-    "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
-    "Microsoft.VisualStudio.Component.Vcpkg",
     "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
-    "Microsoft.Component.VC.Runtime.UCRTSDK",
-    "Microsoft.VisualStudio.Workload.NativeDesktop",
     "Microsoft.VisualStudio.Component.WinXP",
     "Microsoft.VisualStudio.Component.VC.v141.ATL"
-  ],
+  ]
 }

--- a/launcher/Makefile
+++ b/launcher/Makefile
@@ -1,11 +1,6 @@
 all:
 	+$(MAKE) -f Makefile.actual ARCH=32
-ifeq ($(CI),1)
-	@# HACK: Use the 32-bit binary for nightlies for now, until we have a working 64-bit toolchain
-	cp obj/LegacyUpdate32.exe obj/LegacyUpdate64.exe
-else
 	+$(MAKE) -f Makefile.actual ARCH=64
-endif
 
 clean:
 	rm -rf obj


### PR DESCRIPTION
This pull request updates the CI system to use the new toolchain that I just created for GCC 14.2, MinGW 12.0.0, and Binutils 2.43.1. More details on how that was done can be found at https://github.com/LegacyUpdate/mingw-for-legacy-update

I've also fixed a problem in the CI where we were calling unzip without having it installed. This was being done when the Visual Studio installer failed to run, but a default Ubuntu installation doesn't have unzip :)

In addition I've also reverted the CI hack which should allow for nightlies to produce 64-bit versions of LegacyUpdate again.