### PR TITLE
Fix a build failure due to a missing include

### DIFF
--- a/LegacyUpdate/Utils.cpp
+++ b/LegacyUpdate/Utils.cpp
@@ -3,6 +3,7 @@
 #include <atlstr.h>
 #include "HResult.h"
 #include "WMI.h"
+#include "VersionInfo.h"
 
 #pragma comment(lib, "version.lib")
 #pragma comment(lib, "advapi32.lib")


### PR DESCRIPTION
Without this, we don't have the IsWinXP2003 macro, so we'll get a build failure.

Fixes #296 