### PR TITLE
Fix activation status not being correctly reported

### DIFF
--- a/nsisplugin/IsActivated.c
+++ b/nsisplugin/IsActivated.c
@@ -63,7 +63,14 @@ PLUGIN_METHOD(IsActivated) {
 			goto end_slc;
 		}
 
-		g_isActivated = status->eStatus == SL_LICENSING_STATUS_LICENSED;
+		// Iterate through all statuses until we find one in Licensed status.
+		g_isActivated = FALSE;
+		for (int i = 0; i < count; i++) {
+			if (status[i].eStatus == SL_LICENSING_STATUS_LICENSED) {
+				g_isActivated = TRUE;
+				break;
+			}
+		}
 
 end_slc:
 		if (status) {


### PR DESCRIPTION
Fixes https://github.com/LegacyUpdate/LegacyUpdate/issues/290.

Windows has multiple SKUs that get reported through the licensing service but typically only one will be in the licensed state depending on the edition/version. This change checks all reported SKUs and assumes the system is activated if at least one is in the licensed state.