### PR TITLE
CI: Update to setup-wsl-v4, binutils-2.44, and set the default MinGW CRT to msvcrt.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,8 @@ jobs:
 
     - name: Install MinGW toolchain
       run: |
-        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686-v2.tar.xz -o /tmp/mingw32.tar.xz
-        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64-v2.tar.xz -o /tmp/mingw64.tar.xz
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.44-mingw-v12.0.0-i686.tar.xz -o /tmp/mingw32.tar.xz
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.44-mingw-v12.0.0-x86_64.tar.xz -o /tmp/mingw64.tar.xz
         sudo tar -xf /tmp/mingw32.tar.xz -C /opt
         sudo tar -xf /tmp/mingw64.tar.xz -C /opt
         rm /tmp/mingw{32,64}.tar.xz
@@ -61,8 +61,8 @@ jobs:
     - name: Build
       id: build
       run: |
-        export PATH=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686/bin:$PATH
-        export PATH=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64/bin:$PATH
+        export PATH=/opt/gcc-14.2-binutils-2.44-mingw-v12.0.0-i686/bin:$PATH
+        export PATH=/opt/gcc-14.2-binutils-2.44-mingw-v12.0.0-x86_64/bin:$PATH
         make CI=1 DEBUG=0
         echo "out=$(echo setup/LegacyUpdate-*.exe)" >> "$(wslpath -u "$GITHUB_OUTPUT")"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Install WSL
-      uses: Vampire/setup-wsl@v3
+      uses: Vampire/setup-wsl@v4
       with:
         distribution: Ubuntu-22.04
 


### PR DESCRIPTION
This update to CI brings the following changes:

- Updates the setup-wsl action to v4 (adding support for Server 2025 when we move the CI runner to it)
- Updates the MinGW toolchain to Binutils 2.44
- Sets the default MinGW CRT to msvcrt instead of UCRT.