### PR TITLE
Fix missing Uninstall.exe regression from 1.10

### DIFF
--- a/setup/setup.nsi
+++ b/setup/setup.nsi
@@ -130,6 +130,7 @@ FunctionEnd
 Function MakeUninstallEntry
 	${IfNot} $UninstallInstalled == 1
 		StrCpy $UninstallInstalled 1
+		SetOutPath $INSTDIR
 		WriteUninstaller "$INSTDIR\Uninstall.exe"
 
 		; Add uninstall entry


### PR DESCRIPTION
This PR fixes a regression introduced by ee599b6 that resulted in `Uninstall.exe` missing from new Legacy Update installations, preventing the program from being properly uninstalled.