### PR TITLE
Update the CI system to fix warnings and other problems

### DIFF
--- a/.github/workflows/build-nt4.yml
+++ b/.github/workflows/build-nt4.yml
@@ -19,7 +19,6 @@ jobs:
       run: |
         sudo apt-get update -q
         sudo apt-get install -qy curl make mingw-w64-x86-64-dev nsis p7zip-full upx-ucl unzip
-        sudo ./build/fix-nsis.sh
 
     - name: Install MinGW toolchain
       run: |

--- a/.github/workflows/build-nt4.yml
+++ b/.github/workflows/build-nt4.yml
@@ -23,8 +23,8 @@ jobs:
 
     - name: Install MinGW toolchain
       run: |
-        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.44-mingw-v12.0.0-i686.tar.xz -o /tmp/mingw32.tar.xz
-        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.44-mingw-v12.0.0-x86_64.tar.xz -o /tmp/mingw64.tar.xz
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-15.1-binutils-2.44-mingw-v12.0.0-i686.tar.xz -o /tmp/mingw32.tar.xz
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-15.1-binutils-2.44-mingw-v12.0.0-x86_64.tar.xz -o /tmp/mingw64.tar.xz
         sudo tar -xf /tmp/mingw32.tar.xz -C /opt
         sudo tar -xf /tmp/mingw64.tar.xz -C /opt
         rm /tmp/mingw{32,64}.tar.xz
@@ -36,8 +36,8 @@ jobs:
     - name: Build
       id: build
       run: |
-        export PATH=/opt/gcc-14.2-binutils-2.44-mingw-v12.0.0-i686/bin:$PATH
-        export PATH=/opt/gcc-14.2-binutils-2.44-mingw-v12.0.0-x86_64/bin:$PATH
+        export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v12.0.0-i686/bin:$PATH
+        export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v12.0.0-x86_64/bin:$PATH
         make CI=1 DEBUG=0 nt4
 
     - name: Upload Build Artifact

--- a/.github/workflows/build-nt4.yml
+++ b/.github/workflows/build-nt4.yml
@@ -29,6 +29,12 @@ jobs:
         sudo tar -xf /tmp/mingw64.tar.xz -C /opt
         rm /tmp/mingw{32,64}.tar.xz
 
+    - name: Install custom NSIS package
+      run: |
+        curl -fsSL https://linuxfromscratch.org/~renodr/nsis-3.11-ubuntu24.tar.xz -o /tmp/nsis-3.11.tar.xz
+        sudo tar -xf /tmp/nsis-3.11.tar.xz -C /opt
+        rm /tmp/nsis-3.11.tar.xz
+
     - name: Download patches
       run: |
         ./build/get-nt4-patches.sh
@@ -38,6 +44,7 @@ jobs:
       run: |
         export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v12.0.0-i686/bin:$PATH
         export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v12.0.0-x86_64/bin:$PATH
+        export PATH=/opt/nsis-3.11/bin:$PATH
         make CI=1 DEBUG=0 nt4
 
     - name: Upload Build Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install WSL
       uses: Vampire/setup-wsl@v5
       with:
-        distribution: Ubuntu-22.04
+        distribution: Ubuntu-24.04
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Install WSL
-      uses: Vampire/setup-wsl@v4
+      uses: Vampire/setup-wsl@v5
       with:
         distribution: Ubuntu-22.04
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,11 +58,18 @@ jobs:
         sudo tar -xf /tmp/mingw64.tar.xz -C /opt
         rm /tmp/mingw{32,64}.tar.xz
 
+    - name: Install custom NSIS package
+      run: |
+        curl -fsSL https://linuxfromscratch.org/~renodr/nsis-3.11-ubuntu24.tar.xz -o /tmp/nsis-3.11.tar.xz
+        sudo tar -xf /tmp/nsis-3.11.tar.xz -C /opt
+        rm /tmp/nsis-3.11.tar.xz
+
     - name: Build
       id: build
       run: |
         export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v12.0.0-i686/bin:$PATH
         export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v12.0.0-x86_64/bin:$PATH
+        export PATH=/opt/nsis-3.11/bin:$PATH
         make CI=1 DEBUG=0
 
     - name: Upload Build Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,8 @@ jobs:
 
     - name: Install MinGW toolchain
       run: |
-        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.44-mingw-v12.0.0-i686.tar.xz -o /tmp/mingw32.tar.xz
-        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-14.2-binutils-2.44-mingw-v12.0.0-x86_64.tar.xz -o /tmp/mingw64.tar.xz
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-15.1-binutils-2.44-mingw-v12.0.0-i686.tar.xz -o /tmp/mingw32.tar.xz
+        curl -fsSL https://linuxfromscratch.org/~renodr/gcc-15.1-binutils-2.44-mingw-v12.0.0-x86_64.tar.xz -o /tmp/mingw64.tar.xz
         sudo tar -xf /tmp/mingw32.tar.xz -C /opt
         sudo tar -xf /tmp/mingw64.tar.xz -C /opt
         rm /tmp/mingw{32,64}.tar.xz
@@ -61,8 +61,8 @@ jobs:
     - name: Build
       id: build
       run: |
-        export PATH=/opt/gcc-14.2-binutils-2.44-mingw-v12.0.0-i686/bin:$PATH
-        export PATH=/opt/gcc-14.2-binutils-2.44-mingw-v12.0.0-x86_64/bin:$PATH
+        export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v12.0.0-i686/bin:$PATH
+        export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v12.0.0-x86_64/bin:$PATH
         make CI=1 DEBUG=0
 
     - name: Upload Build Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,6 @@ jobs:
       run: |
         sudo apt-get update -q
         sudo apt-get install -qy curl make mingw-w64-x86-64-dev nsis p7zip-full upx-ucl unzip
-        sudo ./build/fix-nsis.sh
 
     - name: Set up Visual Studio
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-2025
     defaults:
       run:
         shell: wsl-bash {0}


### PR DESCRIPTION
This is the May 2025 CI update. I've done the following here:

- Upgraded to setup-wsl v5
- Upgraded to Ubuntu 24.04
- Upgraded to Windows Server 2025
- Upgraded the toolchain - added NSIS 3.11 (to fix CVE-2025-43715), updated to GCC 15.1.0 and MPFR 4.3.1