### PR TITLE
Install KB950050 on Windows Server 2008 with Hyper-V enabled

### DIFF
--- a/setup/DownloadVista78.nsh
+++ b/setup/DownloadVista78.nsh
@@ -90,6 +90,28 @@ FunctionEnd
 ; Windows Vista Servicing Stack Update
 !insertmacro MSUHandler "KB4493730" "2019-04 $(SSU) for Windows $(SRV) 2008"
 
+; Hyper-V Update for Windows Server 2008
+!insertmacro MSUHandler "KB950050" "Hyper-V $(Update) for Windows $(SRV) 2008"
+
+; Only check/apply KB950050 if the Hyper-V role is present on 2008 SP1
+; This update is integrated in SP2
+Function NeedsHyperV2008Update
+	${If} ${IsWinVista}
+	${AndIf} ${IsServerOS}
+	${AndIf} ${AtMostServicePack} 1
+		; Get version of Hyper-V boot driver.
+		${GetFileVersion} "$WINDIR\system32\drivers\hvboot.sys" $0
+		${VersionCompare} $0 "6.0.6001.18016" $1
+		${If} $1 == 2 ; Less than
+			Push 1
+		${Else}
+			Push 0
+		${EndIf}
+	${Else}
+		Push 0
+	${EndIf}
+FunctionEnd
+
 ; Windows 7 Servicing Stack Update
 !insertmacro MSUHandler "KB3138612" "2016-03 $(SSU) for Windows 7"
 !insertmacro MSUHandler "KB4474419" "$(SHA2) for Windows 7"

--- a/setup/Patches.ini
+++ b/setup/Patches.ini
@@ -493,6 +493,14 @@ x86-sha256=de20f531dede818aa65c05194b1e7bfed163dd060dc5214c85629d2e8c760fe3
 x64=03/wu-ie9-windowsvista-x64_f599c02e7e1ea8a4e1029f0e49418a8be8416367.exe
 x64-sha256=e9c8ee3418f92b93a4f0759f527f4fd63215f6bc9fbbd1d86131d0ec49cce95d
 
+; Hyper-V update for Server 08
+[KB950050]
+Prefix=http://download.windowsupdate.com/msdownload/update/software/updt/2008/06/
+x86=windows6.0-kb950050-x86_ca9c19235f4789743d1d818c33726e0f2600238a.msu
+x86-sha264=3ba4464725f19fb11b1a1d16f02f3e871d0bbb208cd4219acd2afa80e4a0cbda
+x64=windows6.0-kb950050-x64_0440bab6c829c0cc052473e34d42e18d37745a91.msu
+x64-sha256=a7a9c40dbbceec3981fb923b8d55600b0e0095980f482d67dca781603744f87c
+
 ; 7/Server 08 R2
 [Win7SP1]
 x86=http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe

--- a/setup/Strings.nsh
+++ b/setup/Strings.nsh
@@ -174,6 +174,7 @@ LangString CTL      ${LANG_ENGLISH} "Certificate Trust List"
 LangString Unofficial ${LANG_ENGLISH} "(Unofficial)"
 
 LangString SectionWES09     ${LANG_ENGLISH} "Enable Windows Embedded 2009 updates"
+LangString SectionWS2008HVU ${LANG_ENGLISH} "Hyper-V $(Update) for Windows Server 2008"
 LangString SectionWHS2011U4 ${LANG_ENGLISH} "Windows Home Server 2011 $(Rollup) 4"
 LangString SectionW2KUR1    ${LANG_ENGLISH} "Update Rollup 1 for Windows 2000 $(SP) 4"
 LangString SectionSSU       ${LANG_ENGLISH} "Windows Servicing Stack update"
@@ -215,6 +216,8 @@ LangString SectionWin81U1Desc   ${LANG_ENGLISH} \
 	"Updates Windows 8.1 to Update 1, as required to resolve issues with the Windows Update Agent. Also required to upgrade to Windows 10."
 LangString SectionWin81SSUDesc  ${LANG_ENGLISH} \
 	"Updates Windows 8.1 or Windows Server 2012 R2 with additional updates required to resolve issues with the Windows Update Agent."
+LangString SectionWS2008HVUDesc ${LANG_ENGLISH} \
+	"Updates Windows Server 2008 to the released version of Hyper-V, as required to install Service Pack 2."
 LangString SectionWHS2011U4Desc ${LANG_ENGLISH} \
 	"Updates Windows Home Server 2011 to Update Rollup 4 to resolve issues with the Windows Update Agent. Also fixes data corruption problems."
 LangString SectionWUADesc       ${LANG_ENGLISH} \

--- a/setup/setup.nsi
+++ b/setup/setup.nsi
@@ -229,6 +229,14 @@ ${MementoSection} "Windows XP/$(SRV) 2003 $(SP) 2" 2003SP2
 ${MementoSectionEnd}
 
 ; Vista prerequisities
+Section "$(SectionWS2008HVU)" WS2008HVU
+	SectionIn Ro
+	${If} ${NeedsPatch} HyperV2008Update
+		Call InstallKB950050
+		${RebootIfRequired}
+	${EndIf}
+SectionEnd
+
 Section "Windows Vista $(SP) 2" VISTASP2
 	SectionIn Ro
 	${RebootIfRequired}
@@ -622,6 +630,7 @@ SectionEnd
 	!insertmacro DESCRIPTION_STRING WIN8SSU
 	!insertmacro DESCRIPTION_STRING WIN81U1
 	!insertmacro DESCRIPTION_STRING WIN81SSU
+	!insertmacro DESCRIPTION_STRING WS2008HVU
 	!insertmacro DESCRIPTION_STRING WHS2011U4
 	!insertmacro DESCRIPTION_STRING WUA
 	!insertmacro DESCRIPTION_STRING ROOTCERTS
@@ -713,6 +722,10 @@ Function .onInit
 
 	${If} ${IsWinVista}
 		; Determine whether Vista prereqs need to be installed
+		${IfNot} ${NeedsPatch} HyperV2008Update
+			!insertmacro RemoveSection ${WS2008HVU}
+		${EndIf}
+
 		${IfNot} ${NeedsPatch} VistaSP2
 			!insertmacro RemoveSection ${VISTASP2}
 		${EndIf}
@@ -725,6 +738,7 @@ Function .onInit
 			!insertmacro RemoveSection ${VISTAIE9}
 		${EndIf}
 	${Else}
+		!insertmacro RemoveSection ${WS2008HVU}
 		!insertmacro RemoveSection ${VISTASP2}
 		!insertmacro RemoveSection ${VISTASSU}
 		!insertmacro RemoveSection ${VISTAIE9}
@@ -879,6 +893,10 @@ Function PreDownload
 
 	; Vista
 	${If} ${IsWinVista}
+		${If} ${NeedsPatch} HyperV2008Update
+			Call DownloadKB950050
+		${EndIf}
+
 		Call DownloadVistaSP1
 		Call DownloadVistaSP2
 		Call DownloadKB3205638


### PR DESCRIPTION
The original release of Windows Server 2008 (RTM/SP1) shipped with a beta/RC version of Hyper-V. KB950050 updates Hyper-V to the final release version and is a prerequisite to installing SP2 if the Hyper-V role is enabled. This seems to only apply to regular editions as the standalone Hyper-V Server has this update already applied.

This PR adds KB950050 to the updates that are installed as part of setup.